### PR TITLE
HTK read/write now validates; pylint/flake8 cleaning

### DIFF
--- a/M2_Speech_Signal_Processing/M2_Wav2Feat_Single.py
+++ b/M2_Speech_Signal_Processing/M2_Wav2Feat_Single.py
@@ -1,3 +1,4 @@
+"""Calculate features for a single file."""
 import os
 import soundfile as sf
 import numpy as np
@@ -6,28 +7,28 @@ import htk_featio as htk
 import speech_sigproc as sp
 
 data_dir = '../Experiments'
-wav_file='../LibriSpeech/dev-clean/1272/128104/1272-128104-0000.flac'
-feat_file=os.path.join(data_dir,'feat/1272-128104-0000.feat')
-plot_output=True
+wav_file = '../LibriSpeech/dev-clean/1272/128104/1272-128104-0000.flac'
+feat_file = os.path.join(data_dir, 'feat/1272-128104-0000.feat')
+plot_output = True
 
 if not os.path.isfile(wav_file):
-    raise RuntimeError('input wav file is missing. Have you downloaded the LibriSpeech corpus?')
+    raise RuntimeError('input wav file is missing. Have you downloaded the '
+                       'LibriSpeech corpus?')
 
-if not os.path.exists(os.path.join(data_dir,'feat')):
-    os.mkdir(os.path.join(data_dir,'feat'))
+if not os.path.exists(os.path.join(data_dir, 'feat')):
+    os.mkdir(os.path.join(data_dir, 'feat'))
 
 samp_rate = 16000
 
 x, s = sf.read(wav_file)
-if (s != samp_rate):
+if s != samp_rate:
     raise RuntimeError("LibriSpeech files are 16000 Hz, found {0}".format(s))
 
-fe = sp.FrontEnd(samp_rate=samp_rate,mean_norm_feat=True)
-
+fe = sp.FrontEnd(samp_rate=samp_rate, mean_norm_feat=True)
 
 feat = fe.process_utterance(x)
 
-if (plot_output):
+if plot_output:
     if not os.path.exists('fig'):
         os.mkdir('fig')
 
@@ -35,6 +36,31 @@ if (plot_output):
     plt.plot(x)
     plt.title('waveform')
     plt.savefig('fig/waveform.png', bbox_inches='tight')
+    plt.close()
+
+    # plot waveform after pre-emphasis
+    xp = fe.pre_emphasize(x)
+    plt.plot(xp)
+    plt.title('waveform with pre-emphasis')
+    plt.savefig('fig/waveform-pre.png', bbox_inches='tight')
+    plt.close()
+
+    # plot the mag spectrum
+    frames = fe.wav_to_frames(x)
+    magspec = fe.frames_to_magspec(frames)
+    # plt.imshow(np.log(magspec + 1e-7), cmap='viridis', origin='lower')
+    plt.imshow(np.log(magspec + 1e-7), origin='lower')
+    plt.title('Log Magnitude Spectrogram')
+    plt.savefig('fig/log_mag_spec.png', bbox_inches='tight')
+    plt.close()
+
+    # plot the mag spectrum after pre-emphasis
+    frames = fe.wav_to_frames(xp)
+    magspec = fe.frames_to_magspec(frames)
+    # plt.imshow(np.log(magspec + 1e-7), cmap='viridis', origin='lower')
+    plt.imshow(np.log(magspec + 1e-7), origin='lower')
+    plt.title('Log Magnitude Spectrogram After Pre-emphasis')
+    plt.savefig('fig/log_mag_spec_p.png', bbox_inches='tight')
     plt.close()
 
     # plot mel filterbank
@@ -45,18 +71,20 @@ if (plot_output):
     plt.close()
 
     # plot log mel spectrum (fbank)
-    plt.imshow(feat, origin='lower', aspect=4) # flip the image so that vertical frequency axis goes from low to high
+    # flip the image so that vertical frequency axis goes from low to high
+    plt.imshow(feat, origin='lower', aspect=4)
     plt.title('log mel filterbank features (fbank)')
     plt.savefig('fig/fbank.png', bbox_inches='tight')
     plt.close()
 
 htk.write_htk_user_feat(feat, feat_file)
-print("Wrote {0} frames to {1}".format(feat.shape[1], feat_file))
+print(f"Wrote {feat.shape[1]} frames to {feat_file}")
 
-# if you want to verify, that the file was written correctly:
-#feat2 = htk.read_htk_user_feat(name=feat_file)
-#print("Read {0} frames rom {1}".format(feat2.shape[1], feat_file))
-#print("Per-element absolute error is {0}".format(np.linalg.norm(feat-feat2)/(feat2.shape[0]*feat2.shape[1])))
-
-
-
+# Verify that the file was written correctly
+feat2 = htk.read_htk_user_feat(name=feat_file)
+print(f"Read {feat2.shape[1]} frames from {feat_file}")
+print(
+    f"Features are {'the same' if np.allclose(feat, feat2) else 'different'}")
+print(
+    f"Average Frobenius norm difference:  "
+    f"{np.linalg.norm(feat - feat2) / (feat.shape[0] * feat.shape[1]):.2e}")

--- a/M2_Speech_Signal_Processing/htk_featio.py
+++ b/M2_Speech_Signal_Processing/htk_featio.py
@@ -1,47 +1,61 @@
+"""Functions to manages features in HTK format."""
 import struct
-import numpy as np
 import sys
 
+import numpy as np
+
+
 def write_htk_user_feat(x, name='filename'):
-    default_period = 100000 # assumes 0.010 ms frame shift
+    """Store features in HTK format."""
+    default_period = 100000  # assumes 0.010 ms frame shift
     num_dim = x.shape[0]
     num_frames = x.shape[1]
+
+    # Create header struct
     hdr = struct.pack(
-        '>iihh',  # the beginning '>' says write big-endian
+        '>IIHH',  # the beginning '>' says write big-endian
         num_frames,  # nSamples
         default_period,  # samplePeriod
-        4*num_dim,  # 2 floats per feature
+        4 * num_dim,  # 2 floats per feature
         9)  # user features
 
     out_file = open(name, 'wb')
     out_file.write(hdr)
 
-    for t in range(0, num_frames):
-        frame = np.array(x[:,t],'f')
+    for t in range(num_frames):
+        frame = np.array(x[:, t], 'f')
         if sys.byteorder == 'little':
             frame.byteswap(True)
         frame.tofile(out_file)
 
     out_file.close()
 
+
 def read_htk_user_feat(name='filename'):
-    f = open(name,'rb')
+    """Retrieve features stored in HTK format."""
+    f = open(name, 'rb')
     hdr = f.read(12)
-    num_samples, samp_period, samp_size, parm_kind = struct.unpack(">IIHH", hdr)
+    num_frames, _, samp_size, parm_kind = struct.unpack(">IIHH", hdr)
     if parm_kind != 9:
-        raise RuntimeError('feature reading code only validated for USER feature type for this lab. There is other publicly available code for general purpose HTK feature file I/O\n')
+        raise RuntimeError(
+            'feature reading code only validated for USER '
+            'feature type for this lab. There is other publicly available '
+            'code for general purpose HTK feature file I/O\n')
 
-    num_dim = samp_size//4
+    num_dim = samp_size // 4
 
-    feat = np.zeros([num_samples, num_dim],dtype=float)
-    for t in range(num_samples):
-        feat[t,:] = np.array(struct.unpack('>' + ('f' * num_dim), f.read(samp_size)),dtype=float)
+    feat = np.zeros([num_dim, num_frames], 'f')
+    for t in range(num_frames):
+        feat[:, t] = np.array(
+            struct.unpack('>' + ('f' * num_dim), f.read(samp_size)),
+            dtype=float)
 
     return feat
 
 
-def write_ascii_stats(x,name='filename'):
-    out_file = open(name,'w')
+def write_ascii_stats(x, name='filename'):
+    """Write ASCII statistics."""
+    out_file = open(name, 'w')
     for t in range(0, x.shape[0]):
         out_file.write("{0}\n".format(x[t]))
     out_file.close()


### PR DESCRIPTION
In the original code the `feat` array gets transposed between read and write, so the validation step at the end would fail. This is fixed in this PR. It is assumed that the write format is the correct one.

There are many other changes that are more cosmetic. I modified things a lot as I was working through the code to understand it.